### PR TITLE
feat: add voice dictation for Claude instances

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -90,7 +90,7 @@
     
     .instance-header {
       display: grid;
-      grid-template-columns: auto 1fr auto auto;
+      grid-template-columns: auto 1fr auto auto auto;
       align-items: center;
       gap: 8px;
       margin-bottom: 3px;
@@ -370,6 +370,56 @@
       border-color: #f14c4c;
     }
     
+    /* Voice dictation button styles */
+    .voice-btn {
+      background: #673ab7;
+      color: white;
+      border: none;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      cursor: pointer;
+      font-size: 14px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.2s ease;
+      position: relative;
+    }
+    
+    .voice-btn:hover {
+      background: #5e35b1;
+      transform: scale(1.1);
+    }
+    
+    .voice-btn.recording {
+      background: #f44336;
+      animation: pulse 1.5s infinite;
+    }
+    
+    .voice-btn.recording::after {
+      content: '';
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      width: 8px;
+      height: 8px;
+      background: #ff5252;
+      border-radius: 50%;
+      animation: blink 1s infinite;
+    }
+    
+    @keyframes pulse {
+      0% { box-shadow: 0 0 0 0 rgba(244, 67, 54, 0.7); }
+      70% { box-shadow: 0 0 0 10px rgba(244, 67, 54, 0); }
+      100% { box-shadow: 0 0 0 0 rgba(244, 67, 54, 0); }
+    }
+    
+    @keyframes blink {
+      0%, 50% { opacity: 1; }
+      51%, 100% { opacity: 0; }
+    }
+    
     .no-instances {
       text-align: center;
       color: #888;
@@ -536,6 +586,7 @@
       display: flex;
       justify-content: space-between;
       align-items: flex-end;
+      gap: 4px;
     }
     
     .tile-info {
@@ -597,6 +648,33 @@
       flex-shrink: 0;
       white-space: nowrap;
     }
+    
+    /* Voice button in tiles */
+    .tile-voice-btn {
+      background: #673ab7;
+      color: white;
+      border: none;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      cursor: pointer;
+      font-size: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.2s ease;
+      flex-shrink: 0;
+    }
+    
+    .tile-voice-btn:hover {
+      background: #5e35b1;
+      transform: scale(1.1);
+    }
+    
+    .tile-voice-btn.recording {
+      background: #f44336;
+      animation: pulse 1.5s infinite;
+    }
   </style>
 </head>
 <body>
@@ -620,6 +698,144 @@
     const { ipcRenderer } = require('electron');
     let currentInstances = new Map();
     let isMinimized = false;
+    let currentRecording = null;
+    let recognition = null;
+    
+    // Initialize Web Speech API
+    function initSpeechRecognition() {
+      if ('webkitSpeechRecognition' in window) {
+        recognition = new webkitSpeechRecognition();
+        recognition.continuous = false;
+        recognition.interimResults = true;
+        recognition.lang = 'en-US';
+        
+        recognition.onstart = () => {
+          console.log('Voice recognition started');
+          updateRecordingUI(true);
+        };
+        
+        recognition.onresult = (event) => {
+          let finalTranscript = '';
+          let interimTranscript = '';
+          
+          for (let i = event.resultIndex; i < event.results.length; i++) {
+            const transcript = event.results[i][0].transcript;
+            if (event.results[i].isFinal) {
+              finalTranscript += transcript;
+            } else {
+              interimTranscript += transcript;
+            }
+          }
+          
+          // Show real-time transcription (optional - could add UI for this)
+          console.log('Interim:', interimTranscript);
+          console.log('Final:', finalTranscript);
+          
+          if (finalTranscript && currentRecording) {
+            sendDictatedText(currentRecording.pid, currentRecording.tty, finalTranscript);
+          }
+        };
+        
+        recognition.onerror = (event) => {
+          console.error('Speech recognition error:', event.error);
+          if (event.error === 'not-allowed') {
+            alert('Microphone permission denied. Please allow microphone access and try again.');
+          }
+          stopRecording();
+        };
+        
+        recognition.onend = () => {
+          console.log('Voice recognition ended');
+          stopRecording();
+        };
+      } else {
+        console.error('Web Speech API not supported');
+        alert('Voice dictation is not supported in this browser.');
+      }
+    }
+    
+    // Start voice dictation for a specific instance
+    function startVoiceDictation(pid, tty) {
+      if (!recognition) {
+        initSpeechRecognition();
+      }
+      
+      if (!recognition) {
+        alert('Voice dictation is not available.');
+        return;
+      }
+      
+      // If already recording, stop it
+      if (currentRecording) {
+        stopRecording();
+        return;
+      }
+      
+      currentRecording = { pid, tty };
+      
+      try {
+        recognition.start();
+      } catch (error) {
+        console.error('Failed to start recognition:', error);
+        alert('Failed to start voice dictation. Please try again.');
+        currentRecording = null;
+      }
+    }
+    
+    // Stop recording
+    function stopRecording() {
+      if (recognition && currentRecording) {
+        try {
+          recognition.stop();
+        } catch (error) {
+          console.error('Error stopping recognition:', error);
+        }
+      }
+      currentRecording = null;
+      updateRecordingUI(false);
+    }
+    
+    // Update UI to show recording state
+    function updateRecordingUI(isRecording) {
+      // Update all voice buttons
+      document.querySelectorAll('.voice-btn, .tile-voice-btn').forEach(btn => {
+        if (isRecording && currentRecording) {
+          // Only update the button for the active recording
+          const btnPid = parseInt(btn.getAttribute('onclick').match(/\d+/)[0]);
+          if (btnPid === currentRecording.pid) {
+            btn.classList.add('recording');
+            btn.innerHTML = '🔴';
+          }
+        } else {
+          btn.classList.remove('recording');
+          btn.innerHTML = '🎤';
+        }
+      });
+    }
+    
+    // Send dictated text to the instance
+    async function sendDictatedText(pid, tty, text) {
+      try {
+        const result = await ipcRenderer.invoke('send-text-to-instance', pid, tty, text);
+        if (result.success) {
+          console.log('Text sent successfully:', text);
+          // Visual feedback - flash the instance
+          const instanceEl = document.querySelector(`.instance[data-pid="${pid}"]`);
+          if (instanceEl) {
+            instanceEl.style.borderColor = '#4CAF50';
+            setTimeout(() => {
+              instanceEl.style.borderColor = '';
+            }, 500);
+          }
+        } else {
+          console.error('Failed to send text:', result.error);
+          alert('Failed to send dictated text to the instance.');
+        }
+      } catch (error) {
+        console.error('Error sending text:', error);
+        alert('Error sending dictated text.');
+      }
+    }
     
     // Function to calculate live session duration
     function calculateLiveDuration(startTimestamp) {
@@ -682,6 +898,9 @@
             ` : '<div class="tile-no-git">No Git</div>'}
             ${instance.isHeadless ? '<div class="tile-headless">HEADLESS</div>' : ''}
           </div>
+          <button class="tile-voice-btn" onclick="startVoiceDictation(${instance.pid}, '${instance.tty}')" title="Voice dictation">
+            🎤
+          </button>
           <div class="tile-duration">${instance.startTimestamp ? calculateLiveDuration(instance.startTimestamp) : instance.elapsedTime}</div>
         </div>
       `;
@@ -703,6 +922,9 @@
             ${instance.isHeadless ? 'HEADLESS' : 'INTERACTIVE'}
           </div>
           <div class="session-duration">${instance.startTimestamp ? calculateLiveDuration(instance.startTimestamp) : instance.elapsedTime}</div>
+          <button class="voice-btn" onclick="startVoiceDictation(${instance.pid}, '${instance.tty}')" title="Voice dictation">
+            🎤
+          </button>
         </div>
         <div class="instance-path">
           <div class="full-path">${instance.workingDirectory}</div>
@@ -804,6 +1026,9 @@
             ` : '<div class="tile-no-git">No Git</div>'}
             ${instance.isHeadless ? '<div class="tile-headless">HEADLESS</div>' : ''}
           </div>
+          <button class="tile-voice-btn" onclick="startVoiceDictation(${instance.pid}, '${instance.tty}')" title="Voice dictation">
+            🎤
+          </button>
           <div class="tile-duration">${instance.startTimestamp ? calculateLiveDuration(instance.startTimestamp) : instance.elapsedTime}</div>
         </div>
       `;


### PR DESCRIPTION
## Summary
Add voice dictation capability to send input directly to Claude instances using the Web Speech API and AppleScript integration.

## Features
- **Voice Input**: Click microphone button to dictate text to any Claude instance
- **UI Integration**: 
  - Purple microphone buttons in expanded view headers
  - Small mic icons on minimized tiles
  - Recording state with red indicator and pulsing animation
- **Speech Recognition**:
  - Uses built-in Web Speech API (webkitSpeechRecognition)
  - Real-time transcription with interim results
  - Automatic text delivery on final transcription
- **Terminal Integration**:
  - AppleScript support for iTerm2 and Terminal.app
  - Finds and activates correct terminal window by TTY
  - Sends dictated text directly to the instance
- **Visual Feedback**:
  - Recording indicator with pulsing animation
  - Green border flash on successful text delivery
  - Error alerts for permission or delivery issues

## Technical Implementation
- **Frontend**: Web Speech API with recording state management
- **IPC**: New handler `send-text-to-instance` for text delivery
- **Backend**: AppleScript automation for terminal control
- **Permissions**: Automatic microphone permission handling

## Usage
1. Click the 🎤 button on any Claude instance
2. Speak your command or input
3. Speech is automatically transcribed and sent to the instance
4. Click again to stop recording early

## Notes
- Requires microphone permission (automatically requested)
- Works with interactive instances only (not headless)
- Supports both iTerm2 and Terminal.app
- No external dependencies - uses built-in browser APIs

## Test Plan
- [ ] Test microphone permission request
- [ ] Verify recording starts/stops on button click
- [ ] Confirm speech recognition works
- [ ] Test text delivery to iTerm2
- [ ] Test text delivery to Terminal.app
- [ ] Verify visual feedback (recording indicator, border flash)
- [ ] Test error handling for headless instances