### PR TITLE
Add workflow_dispatch trigger to release workflow for testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release Build
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: 'Enable debug output'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   build:
@@ -46,6 +53,7 @@ jobs:
           ls -la dist/
 
       - name: Find and upload DMG files to release
+        if: github.event_name == 'release'
         run: |
           for dmg_file in dist/*.dmg; do
             if [ -f "$dmg_file" ]; then
@@ -62,6 +70,17 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Debug output (manual dispatch only)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug == 'true'
+        run: |
+          echo "=== Debug Information ==="
+          echo "Event name: ${{ github.event_name }}"
+          echo "Debug enabled: ${{ github.event.inputs.debug }}"
+          echo "Build artifacts:"
+          find dist/ -type f || echo "No dist directory found"
+          echo "=== Environment ==="
+          env | grep -E "(GITHUB_|NODE_)" | sort
 
       - name: Upload build artifacts as workflow artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Add manual trigger capability to the release workflow to enable testing and troubleshooting of the build process without creating actual releases.

## Changes Made

### Workflow Dispatch Trigger
- **Manual Execution**: Added `workflow_dispatch` trigger to release.yml
- **Debug Parameter**: Optional debug input for enhanced troubleshooting output
- **Conditional Logic**: Release upload only occurs for actual release events

### Testing Features
- **Safe Testing**: Manual runs won't upload to releases or create tags
- **Debug Output**: When enabled, shows detailed build artifacts and environment info
- **Artifact Upload**: Still creates workflow artifacts for download and inspection

### Benefits
- Test build process without affecting releases
- Debug build issues in CI environment
- Validate changes to workflow before releasing
- Inspect generated artifacts without publishing

## Usage
1. Go to GitHub Actions tab
2. Select "Release Build" workflow
3. Click "Run workflow"
4. Optionally enable "Enable debug output"
5. Monitor build process and download artifacts

## Technical Details
- Uses conditional `if: github.event_name == 'release'` for release-specific steps
- Debug output shows file listings and environment variables
- Maintains existing release behavior when triggered by actual releases
- Artifacts are always uploaded as workflow artifacts regardless of trigger type

This enables safe testing of the workflow while preserving the existing release automation.

🤖 Generated with [Claude Code](https://claude.ai/code)