### PR TITLE
Fix electron-builder auto-publish token error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "build": {
     "appId": "com.github.dmiracle.claude-monitor",
     "productName": "Claude Monitor",
+    "publish": null,
     "directories": {
       "buildResources": "build"
     },


### PR DESCRIPTION
## Problem
The build workflow was failing because electron-builder was trying to auto-publish when CI was detected, but no GitHub token was available. The error was:

```
⨯ GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
```

However, the build itself was **successful** and created the artifacts:
- `dist/Claude Monitor-0.1.0-arm64-mac.zip`
- `dist/Claude Monitor-0.1.0-arm64.dmg`

## Solution
Added `"publish": null` to the electron-builder configuration in package.json. This:

- Disables electron-builder's automatic publishing when CI is detected
- Still creates all build artifacts (DMG, ZIP, block maps)
- Allows the workflow to handle publishing manually via GitHub CLI
- Prevents the token error that was causing the build to fail

## Result
- Build process completes successfully ✅
- Artifacts are created in `dist/` directory ✅
- Workflow can upload artifacts to releases manually ✅
- No more token-related build failures ✅

## Testing
This should resolve the build failure and allow the workflow to:
1. Build the Electron app successfully
2. Create DMG and ZIP artifacts
3. Upload artifacts to workflow artifacts
4. Upload to GitHub releases (when triggered by actual releases)

🤖 Generated with [Claude Code](https://claude.ai/code)