### PR TITLE
chore: exclude HTML from GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-detectable=false


### PR DESCRIPTION
Adds a .gitattributes marking *.html as linguist-detectable=false so src/index.html no longer skews the repo's language breakdown toward HTML.